### PR TITLE
Feature: Scripts to build backend and destroy all

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,12 +25,6 @@ This is a basic CI/CD pipeline template for projects using AWS, Terraform, and C
     - The prod_deploy job will run terraform apply in the prod context.
 6. Repeat steps 3 to 5 to code and promote changes through dev and prod.
 
-## To Do
-Only the CircleCI config has been implemented so far.
-- Create Terraform for backend
-- Create sample resources
-- Document setup instructions
-
 ## Setup
 1. Set the pipeline tag in variables.tf to the name of the project. This tag is used to name the backend resources in backend-resources.tf
 2. Modify dev.tfbackend and prod.tfbackend and set the bucket and dynamodb_table values to match the name 
@@ -47,3 +41,7 @@ terraform init -force-copy -backend-config=dev.tfbackend
 5. Repeat step 3 replacing "dev" with "prod"
 
 The backends for dev and prod are now created with remote states. 
+
+## To Do
+Only the CircleCI config has been implemented so far.
+- update with terraform 0.12 syntax

--- a/backend-resources.tf
+++ b/backend-resources.tf
@@ -3,7 +3,7 @@
 ################
 resource "aws_s3_bucket" "tf-state-bucket" {
   # Update backend.tf with new value
-  bucket        = "${lower(lookup(var.common_tags, "pipeline"))}-${var.env}-state-bucket"
+  bucket        = "${lower(lookup(var.common_tags, "pipeline"))}-${var.env}-state-bucket-801bc1"
   force_destroy = true
   acl           = "private"
   tags          = "${var.common_tags}"

--- a/destroy.sh
+++ b/destroy.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+# This script unconfigures the s3 backend and destroys all resources
+if [ "$1" != "" ]; then
+    mv backend.tf backend
+    terraform init -force-copy -lock=false
+    terraform destroy -auto-approve -var="env=$1"
+    mv backend backend.tf
+else
+    echo "Usage: $0 [env]"
+fi

--- a/dev.tfbackend
+++ b/dev.tfbackend
@@ -1,5 +1,5 @@
 # replace pipeline-example with the value set for the pipeline tag in variables.tf
-bucket         = "pipeline-example-dev-state-bucket"
+bucket         = "pipeline-example-dev-state-bucket-801bc1"
 dynamodb_table = "pipeline-example-dev-state-table"
 region         = "us-east-1"
 

--- a/prod.tfbackend
+++ b/prod.tfbackend
@@ -1,4 +1,4 @@
 # replace pipeline-example with the value set for the pipeline tag in variables.tf
-bucket         = "pipeline-example-prod-state-bucket"
+bucket         = "pipeline-example-prod-state-bucket-801bc1"
 dynamodb_table = "pipeline-example-prod-state-table"
 region         = "us-east-1"

--- a/setup-backend.sh
+++ b/setup-backend.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+# This script initializes the backend s3 bucket and dynamodb lock table
+if [ "$1" != "" ]; then
+    #rm -Rf .terraform
+    mv backend.tf backend
+    terraform init
+    terraform apply \
+        -target=aws_s3_bucket.tf-state-bucket \
+        -target=aws_dynamodb_table.tf-state-table \
+        -auto-approve \
+        -var="env=$1"
+    mv backend backend.tf
+    terraform init -force-copy -backend-config=$1.tfbackend
+else
+    echo "Usage: $0 [env]"
+fi


### PR DESCRIPTION
- setup-backend.sh - deploys the backend s3 bucket and dynamo db table for locking and moves the state to the s3 backend
- destroy-sh - unconfigures the s3 backend and destroys all resources